### PR TITLE
CoverageWrapper: use config_file

### DIFF
--- a/covimerage/coveragepy.py
+++ b/covimerage/coveragepy.py
@@ -100,7 +100,7 @@ class CoverageWrapper(object):
             def _get_file_reporter(self, morf):
                 return FileReporter(morf)
 
-        cov_coverage = CoverageW(config_file=False)
+        cov_coverage = CoverageW()
         cov_coverage._init()
         cov_coverage.data = self.data.cov_data
         return cov_coverage


### PR DESCRIPTION
This makes `covimerage report` behave as `coverage report` with regard to config settings.