### PR TITLE
tests: harden/fix for custom/project .coveragerc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ common: &common
     - restore_cache:
         keys:
           - v1-deps-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}
-          - v1-deps-
     - run: pip install --user tox
     - run: PYTEST_ADDOPTS=-vv ~/.local/bin/tox
     - run:

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ DEPS_QA = [
     'flake8',
     'flake8-isort',
     'flake8-per-file-ignores',
-    'flake8-quotes',
 ]
 DEPS_TESTING = [
     'pytest>=3.3.0',


### PR DESCRIPTION
Do not make test fail when adding `precision = 2` to covimerage's .coveragerc.