### PR TITLE
Change default for --data-file to .coverage_covimerage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ boilerplate:
 covimerage run vim -Nu test/vimrc -c 'Vader! test/**'
 ```
 
-This will write the file `.coverage.covimerage` by default (use `--data-file`
-to configure it), which is compatible to Coverage.py.
+This will write the file `.coverage_covimerage` by default (use `--data-file`
+to configure it), which is compatible with Coverage.py.
 A report is automatically generated (on stdout).
 
 You can then call `covimerage xml` to create a `coverage.xml` file
@@ -56,7 +56,7 @@ This makes Neovim/Vim then write a file with profiling information.
 covimerage write_coverage /tmp/vim-profile.txt
 ```
 
-This will create a file `.coverage.covimerage` (the default for `--data-file`),
+This will create a file `.coverage_covimerage` (the default for `--data-file`),
 with entries marked for processing by a
 [Coverage.py](http://coverage.readthedocs.io/) plugin (provided by
 covimerage)).
@@ -71,7 +71,7 @@ other settings here (for Coverage.py), e.g. to omit some files:
 ```
 [run]
 plugins = covimerage
-data_file = .coverage.covimerage
+data_file = .coverage_covimerage
 ```
 
 ### 4. Create the report(s)

--- a/covimerage/__init__.py
+++ b/covimerage/__init__.py
@@ -13,7 +13,7 @@ from .utils import (
     find_executable_files, get_fname_and_fobj_and_str, is_executable_line,
 )
 
-DEFAULT_COVERAGE_DATA_FILE = '.coverage.covimerage'
+DEFAULT_COVERAGE_DATA_FILE = '.coverage_covimerage'
 RE_FUNC_PREFIX = re.compile(
     r'^\s*fu(?:n(?:(?:c(?:t(?:i(?:o(?:n)?)?)?)?)?)?)?!?\s+')
 RE_CONTINUING_LINE = re.compile(r'\s*\\')

--- a/covimerage/cli.py
+++ b/covimerage/cli.py
@@ -209,8 +209,7 @@ def report(ctx, profile_file, data_file, show_missing, include, omit,
     This will automatically add covimerage as a plugin, and then just forwards
     most options.
 
-    If PROFILE_FILE is provided this gets parsed, otherwise DATA_FILE is
-    being used.
+    If PROFILE_FILE is provided this gets parsed, otherwise DATA_FILE is used.
     """
     # Use None instead of empty set, for coveragepy to use the config file.
     include = include if include else None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -641,7 +641,7 @@ def test_run_append_with_data(runner, tmpdir):
         assert result.output.splitlines() == [
             'Running cmd: printf -- --headless (in %s)' % str(tmpdir),
             'Parsing profile file %s.' % profile_file,
-            'Writing coverage file .coverage.covimerage.',
+            'Writing coverage file .coverage_covimerage.',
             'Name                                         Stmts   Miss  Cover',
             '----------------------------------------------------------------',
             'tests/test_plugin/conditional_function.vim      13      5    62%']
@@ -654,7 +654,7 @@ def test_run_append_with_data(runner, tmpdir):
         assert result.output.splitlines() == [
             'Running cmd: printf -- --headless (in %s)' % str(tmpdir),
             'Parsing profile file %s.' % profile_file,
-            'Writing coverage file .coverage.covimerage.',
+            'Writing coverage file .coverage_covimerage.',
             'Name                                         Stmts   Miss  Cover',
             '----------------------------------------------------------------',
             'tests/test_plugin/conditional_function.vim      13      5    62%']
@@ -674,7 +674,7 @@ def test_run_append_with_data(runner, tmpdir):
         assert result.output.splitlines() == [
             'Running cmd: printf -- --headless (in %s)' % str(tmpdir),
             'Parsing profile file %s.' % profile_file,
-            'Writing coverage file .coverage.covimerage.',
+            'Writing coverage file .coverage_covimerage.',
             'Name                                         Stmts   Miss  Cover',
             '----------------------------------------------------------------',
             'tests/test_plugin/conditional_function.vim      13      5    62%',


### PR DESCRIPTION
`.coverage.covimerage` gets considered by Coverage.py when combining
coverage for `.coverage`, and would cause an exception if branch
coverage is used there, because arc data and lines cannot be combined.