### PR TITLE
Minor: run: required arg, pytest config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ workflows:
   version: 2
   test:
     jobs:
+      - py37
       - py36
       - py35
       - py34

--- a/covimerage/cli.py
+++ b/covimerage/cli.py
@@ -66,7 +66,7 @@ def write_coverage(profile_file, data_file, source, append):
     # ignore_unknown_options=True,
     allow_interspersed_args=False,
 ))
-@click.argument('args', nargs=-1, type=click.UNPROCESSED)
+@click.argument('args', nargs=-1, required=True, type=click.UNPROCESSED)
 @click.option('--wrap-profile/--no-wrap-profile', required=False,
               default=True, show_default=True,
               help='Wrap VIM cmd with options to create a PROFILE_FILE.')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
 testpaths = tests
-addopts = -ra
+addopts = -ra -vv
 
 [isort]
 combine_as_imports = 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -762,3 +762,9 @@ def test_run_forwards_sighup(devnull):
     stderr = stderr.decode()
     assert 'Command exited non-zero: 89' in stderr
     assert exit_code == 89
+
+
+def test_run_cmd_requires_args(runner):
+    result = runner.invoke(cli.run, [])
+    assert 'Error: Missing argument "args".' in result.output.splitlines()
+    assert result.exit_code == 2


### PR DESCRIPTION
pytest: use -vv by default (a separate option would be better likely (https://github.com/pytest-dev/pytest/issues/3962))