### PR TITLE
coveragerc: use parallel=true

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ branch = true
 # Wrong warning caused by include used in [report] (Coveragepy 4.4.2)
 # Ref: https://bitbucket.org/ned/coveragepy/issues/621
 disable_warnings = include-ignored
+parallel = true
 
 [report]
 show_missing = true


### PR DESCRIPTION
Works around https://github.com/nedbat/coveragepy/issues/702 with
coveragepy 5.0a3.

Failing build: https://circleci.com/gh/Vimjas/covimerage/1482