### PR TITLE
Use pipes.quote with Python 2.7

### DIFF
--- a/covimerage/_compat.py
+++ b/covimerage/_compat.py
@@ -11,18 +11,4 @@ except ImportError:
 try:
     from shlex import quote as shell_quote
 except ImportError:
-    import re
-
-    # Copy'n'paste from Python 3.6.2.
-    _find_unsafe = re.compile(r'[^a-zA-Z0-9_@%+=:,./-]').search
-
-    def shell_quote(s):
-        """Return a shell-escaped version of the string *s*."""
-        if not s:
-            return "''"
-        if _find_unsafe(s) is None:
-            return s
-
-        # use single quotes, and put single quotes into double quotes
-        # the string $'b is then quoted as '$'"'"'b'
-        return "'" + s.replace("'", "'\"'\"'") + "'"
+    from pipes import quote as shell_quote  # noqa: F401


### PR DESCRIPTION
Python 2.7 has `pipes.quote`, where `shlex.quote` was based upon.