### PR TITLE
Handle new "Defined:" format with Vim patch 8.1.2055

### DIFF
--- a/covimerage/__init__.py
+++ b/covimerage/__init__.py
@@ -432,7 +432,10 @@ class Profile(object):
                     if next_line.startswith('count'):
                         break
                     if next_line.startswith('    Defined:'):
-                        fname, lnum = next_line[13:].rstrip().rsplit(' line ', 1)  # noqa: E501
+                        defined = next_line[13:]
+                        fname, _, lnum = defined.rpartition(":")
+                        if not fname:
+                            fname, _, lnum = defined.rpartition(' line ')
                         fname = os.path.expanduser(fname)
                         in_function.source = (self.scripts_by_fname[fname],
                                               int(lnum))


### PR DESCRIPTION
Ref: https://github.com/vim/vim/commit/181d4f58cc421f2e6d3b16333d4cb70d35ad1342