### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ common: &common
   steps:
     - checkout
     - run: pip install --user tox
+    - run: ~/.local/bin/tox --version
     - run: PYTEST_ADDOPTS=-vv ~/.local/bin/tox
     - run:
         name: upload coverage results for non-checkqa builds

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     install_requires=[
         'attrs>=16.1.0',
         'click',
-        'coverage<5',
+        'coverage<=5.0a5',
     ],
     extras_require={
         'testing': DEPS_TESTING,


### PR DESCRIPTION
Fixes:

> pip._vendor.pkg_resources.ContextualVersionConflict: (coverage 5.0a5
> (…/lib/python3.7/site-packages), Requirement.parse('coverage<5'), {'covimerage'})